### PR TITLE
Allow passing context to methods, add optional config for client

### DIFF
--- a/cancel.go
+++ b/cancel.go
@@ -1,5 +1,9 @@
 package tinkoff
 
+import (
+	"context"
+)
+
 type CancelRequest struct {
 	BaseRequest
 
@@ -27,8 +31,15 @@ type CancelResponse struct {
 	PaymentID      string `json:"PaymentId"`      // Уникальный идентификатор транзакции в системе Банка
 }
 
+// Cancel cancels the payment
+// Deprecated: use CancelWithContext instead
 func (c *Client) Cancel(request *CancelRequest) (*CancelResponse, error) {
-	response, err := c.PostRequest("/Cancel", request)
+	return c.CancelWithContext(context.Background(), request)
+}
+
+// CancelWithContext cancels the payment
+func (c *Client) CancelWithContext(ctx context.Context, request *CancelRequest) (*CancelResponse, error) {
+	response, err := c.PostRequestWithContext(ctx, "/Cancel", request)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -1,8 +1,9 @@
-// Package tinkoff allows to send token-signed requests to Tinkoff Acquiring API and parse incoming HTTP notifications
+// Package tinkoff allows sending token-signed requests to Tinkoff Acquiring API and parse incoming HTTP notifications
 package tinkoff
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -10,19 +11,64 @@ import (
 	"sort"
 )
 
-// Client is the main entity which execute request against the Tinkoff Acquiring API endpoint
-type Client struct {
+type Config struct {
+	httpClient *http.Client
+
 	terminalKey string
 	password    string
 	baseURL     string
 }
 
+func WithTerminalKey(terminalKey string) func(*Config) {
+	return func(config *Config) {
+		config.terminalKey = terminalKey
+	}
+}
+
+func WithPassword(password string) func(*Config) {
+	return func(config *Config) {
+		config.password = password
+	}
+}
+
+func WithBaseURL(baseURL string) func(*Config) {
+	return func(config *Config) {
+		config.baseURL = baseURL
+	}
+}
+
+func WithHTTPClient(c *http.Client) func(*Config) {
+	return func(config *Config) {
+		config.httpClient = c
+	}
+}
+
+// Client is the main entity which executes requests against the Tinkoff Acquiring API endpoint
+type Client struct {
+	Config
+}
+
 // NewClient returns new Client instance
 func NewClient(terminalKey, password string) *Client {
+	return NewClientWithOptions(
+		WithTerminalKey(terminalKey),
+		WithPassword(password),
+	)
+}
+
+func NewClientWithOptions(cfgOption ...func(*Config)) *Client {
+	defaultConfig := Config{
+		httpClient: http.DefaultClient,
+		baseURL:    "https://securepay.tinkoff.ru/v2",
+	}
+	cfg := defaultConfig
+
+	for _, opt := range cfgOption {
+		opt(&cfg)
+	}
+
 	return &Client{
-		terminalKey: terminalKey,
-		password:    password,
-		baseURL:     "https://securepay.tinkoff.ru/v2",
+		Config: cfg,
 	}
 }
 
@@ -35,16 +81,26 @@ func (c *Client) decodeResponse(response *http.Response, result interface{}) err
 	return json.NewDecoder(response.Body).Decode(result)
 }
 
-// PostRequest will automatically sign the request with token
-// Use BaseRequest type to implement any API request
+// Deprecated: use PostRequestWithContext instead
 func (c *Client) PostRequest(url string, request RequestInterface) (*http.Response, error) {
+	return c.PostRequestWithContext(context.Background(), url, request)
+}
+
+// PostRequestWithContext will automatically sign the request with token
+// Use BaseRequest type to implement any API request
+func (c *Client) PostRequestWithContext(ctx context.Context, url string, request RequestInterface) (*http.Response, error) {
 	c.secureRequest(request)
 	data, err := json.Marshal(request)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Post(c.baseURL+url, "application/json", bytes.NewReader(data))
-	return resp, err
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+url, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.httpClient.Do(req)
 }
 
 func (c *Client) secureRequest(request RequestInterface) {

--- a/compound_test.go
+++ b/compound_test.go
@@ -1,6 +1,8 @@
 package tinkoff_test
 
 import (
+	"context"
+	"errors"
 	"strconv"
 	"testing"
 	"time"
@@ -92,6 +94,10 @@ func TestCallsChain(t *testing.T) {
 	resendRes, err := c.Resend()
 	assertNotError(t, err)
 
-	assertEq(t, 0, resendRes.Count)
+	verySmallTimeoutCtx, cancel := context.WithTimeout(context.Background(), 100*time.Nanosecond)
+	defer cancel()
+	_, err = c.ResendWithContext(verySmallTimeoutCtx)
+	assertEq(t, context.DeadlineExceeded, errors.Unwrap(err))
 
+	assertEq(t, 0, resendRes.Count)
 }

--- a/confirm.go
+++ b/confirm.go
@@ -1,5 +1,7 @@
 package tinkoff
 
+import "context"
+
 type ConfirmRequest struct {
 	BaseRequest
 	PaymentID string   `json:"PaymentId"`         // Идентификатор платежа в системе банка
@@ -24,8 +26,15 @@ type ConfirmResponse struct {
 	PaymentID string `json:"PaymentId"` // Идентификатор платежа в системе банка.
 }
 
+// Confirm finalizes the payment
+// Deprecated: use ConfirmWithContext instead
 func (c *Client) Confirm(request *ConfirmRequest) (*ConfirmResponse, error) {
-	response, err := c.PostRequest("/Confirm", request)
+	return c.ConfirmWithContext(context.Background(), request)
+}
+
+// ConfirmWithContext finalizes the payment
+func (c *Client) ConfirmWithContext(ctx context.Context, request *ConfirmRequest) (*ConfirmResponse, error) {
+	response, err := c.PostRequestWithContext(ctx, "/Confirm", request)
 	if err != nil {
 		return nil, err
 	}

--- a/getstate.go
+++ b/getstate.go
@@ -1,5 +1,7 @@
 package tinkoff
 
+import "context"
+
 type GetStateRequest struct {
 	BaseRequest
 
@@ -21,8 +23,15 @@ type GetStateResponse struct {
 	PaymentID string `json:"PaymentId"` // Уникальный идентификатор транзакции в системе Банка
 }
 
+// GetState returns info about payment
+// Deprecated: use GetStateWithContext instead
 func (c *Client) GetState(request *GetStateRequest) (*GetStateResponse, error) {
-	response, err := c.PostRequest("/GetState", request)
+	return c.GetStateWithContext(context.Background(), request)
+}
+
+// GetStateWithContext returns info about payment
+func (c *Client) GetStateWithContext(ctx context.Context, request *GetStateRequest) (*GetStateResponse, error) {
+	response, err := c.PostRequestWithContext(ctx, "/GetState", request)
 	if err != nil {
 		return nil, err
 	}

--- a/init.go
+++ b/init.go
@@ -1,6 +1,7 @@
 package tinkoff
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -61,8 +62,15 @@ type InitResponse struct {
 	PaymentURL string `json:"PaymentURL,omitempty"` // Ссылка на страницу оплаты. По умолчанию ссылка доступна в течении 24 часов.
 }
 
+// Init prepares new payment transaction
+// Deprecated: use InitWithContext instead
 func (c *Client) Init(request *InitRequest) (*InitResponse, error) {
-	response, err := c.PostRequest("/Init", request)
+	return c.InitWithContext(context.Background(), request)
+}
+
+// InitWithContext prepares new payment transaction
+func (c *Client) InitWithContext(ctx context.Context, request *InitRequest) (*InitResponse, error) {
+	response, err := c.PostRequestWithContext(ctx, "/Init", request)
 	if err != nil {
 		return nil, err
 	}

--- a/notification.go
+++ b/notification.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 )
 
@@ -54,8 +53,9 @@ func (n *Notification) GetValuesForToken() map[string]string {
 	return result
 }
 
+// ParseNotification tries to parse payment state change notification body
 func (c *Client) ParseNotification(requestBody io.Reader) (*Notification, error) {
-	bytes, err := ioutil.ReadAll(requestBody)
+	bytes, err := io.ReadAll(requestBody)
 	if err != nil {
 		return nil, err
 	}

--- a/qr.go
+++ b/qr.go
@@ -1,5 +1,7 @@
 package tinkoff
 
+import "context"
+
 type GetQRRequest struct {
 	BaseRequest
 
@@ -37,7 +39,11 @@ func (i *GetQRTestRequest) GetValuesForToken() map[string]string {
 }
 
 func (c *Client) GetQR(request *GetQRRequest) (*GetQRResponse, error) {
-	response, err := c.PostRequest("/GetQr", request)
+	return c.GetQRWithContext(context.Background(), request)
+}
+
+func (c *Client) GetQRWithContext(ctx context.Context, request *GetQRRequest) (*GetQRResponse, error) {
+	response, err := c.PostRequestWithContext(ctx, "/GetQr", request)
 	if err != nil {
 		return nil, err
 	}
@@ -52,11 +58,17 @@ func (c *Client) GetQR(request *GetQRRequest) (*GetQRResponse, error) {
 	return &res, res.Error()
 }
 
-// SPBPayTest тестовый метод описанный в API.
-// на рабочем терминале - функция не работает.
-// тестовый терминал не работает у банка.
+// SPBPayTest test method for SPB
+// It is expected to fail on "production" terminal.
+// Deprecated: use SPBPayTestWithContext instead
 func (c *Client) SPBPayTest(request *GetQRTestRequest) (*GetQRResponse, error) {
-	response, err := c.PostRequest("/SpbPayTest", request)
+	return c.SPBPayTestWithContext(context.Background(), request)
+}
+
+// SPBPayTestWithContext test method for SPB
+// It is expected to fail on "production" terminal.
+func (c *Client) SPBPayTestWithContext(ctx context.Context, request *GetQRTestRequest) (*GetQRResponse, error) {
+	response, err := c.PostRequestWithContext(ctx, "/SpbPayTest", request)
 	if err != nil {
 		return nil, err
 	}

--- a/resend.go
+++ b/resend.go
@@ -1,5 +1,7 @@
 package tinkoff
 
+import "context"
+
 type ResendRequest struct {
 	BaseRequest
 }
@@ -13,8 +15,15 @@ type ResendResponse struct {
 	Count int `json:"Count"` // Количество сообщений, отправляемых повторно
 }
 
+// Resend requests to send unacknowledged notifications again
+// Deprecated: use ResendWithContext instead
 func (c *Client) Resend() (*ResendResponse, error) {
-	response, err := c.PostRequest("/Resend", &ResendRequest{})
+	return c.ResendWithContext(context.Background())
+}
+
+// ResResendWithContextend requests to send unacknowledged notifications again
+func (c *Client) ResendWithContext(ctx context.Context) (*ResendResponse, error) {
+	response, err := c.PostRequestWithContext(ctx, "/Resend", &ResendRequest{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- new alternative XXXWithContext methods have been added, allowing to control HTTP request context
- old methods have been deprecated to encourage proper usage of Go contexts
- new Client constructor allows to change HTTP client and base URL