### PR TITLE
Add `Recurrent` field to token in `Init` operation

### DIFF
--- a/init.go
+++ b/init.go
@@ -45,6 +45,7 @@ func (i *InitRequest) GetValuesForToken() map[string]string {
 		"IP":              i.ClientIP,
 		"Description":     i.Description,
 		"Language":        i.Language,
+		"Recurrent":       i.Recurrent,
 		"CustomerKey":     i.CustomerKey,
 		"RedirectDueDate": i.RedirectDueDate.String(),
 		"NotificationURL": i.NotificationURL,


### PR DESCRIPTION
Привет! Почему то среди полей, которые учавствуют в создании токена для подписи запроса, потерялось поле `Recurrent`. Если создавать первичный рекуррентный платёж с передачей поля `Recurrent: Y`, то вернётся ошибка:

```
unexpected payment status: : error code 204 - Неверные параметры.. Неверный токен. Проверьте пару TerminalKey/SecretKey.
```